### PR TITLE
fix: no timeout for zselect

### DIFF
--- a/shell/dispatch.zsh
+++ b/shell/dispatch.zsh
@@ -24,7 +24,7 @@ function __denovo_dispatch() {
 	fd=$REPLY
 	echo "$request" >&$fd
 	zmodload zsh/zselect
-	while zselect -t 10 -r $_denovo_listen_fd -r $fd 2> /dev/null; do
+	while zselect -r $_denovo_listen_fd -r $fd 2>${DENOVO_ROOT}/zsh.log; do
 		ready_fd=${(s/ /)reply[2]}
 		if (( ready_fd == $fd )); then
 			cat <&$ready_fd


### PR DESCRIPTION
When you run a heavy process with deno and it takes a long time, it will time out and the process will fail, so do not time out!
